### PR TITLE
fix: removed extra identation for generated files .terraform-version …

### DIFF
--- a/infra/terraform/live/terragrunt.hcl
+++ b/infra/terraform/live/terragrunt.hcl
@@ -174,7 +174,7 @@ generate "terraform_version" {
   if_exists         = "overwrite"
   disable_signature = true
 
-  contents = <<EOF
+  contents = <<-EOF
     ${local.tf_version_cfg.locals.terraform_version}
   EOF
 }
@@ -184,7 +184,7 @@ generate "terragrunt_version" {
   if_exists         = "overwrite"
   disable_signature = true
 
-  contents = <<EOF
+  contents = <<-EOF
     ${local.tf_version_cfg.locals.terragrunt_version}
   EOF
 }


### PR DESCRIPTION
## 🎯 What
Provide a concise description of the changes:
* ❓ What changes have you made? (High-level overview)
* 🎉 What does it mean to the user? (In plain English)

fix: removed extra identation for generated files .terraform-version and .terragrunt-version

## 🤔 Why
Explain why the changes are necessary:
* 💡 Why were these changes made? 

Without this fix, the following error occurs: `No versions matching '    1.6.1' found in remote` without even starting terraform.

## 📚 References
Link any supporting context or documentation:
* 🔗 [Heredoc strings](https://developer.hashicorp.com/terraform/language/expressions/strings#heredoc-strings)
