### PR TITLE
ci(provider): Update local provider configuration in module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository embodies a structured approach to organizing Terraform code with
 │       │   │   ├── cloudflare_dns_zone.hcl
 │       │   │   └── random_string.hcl
 │       │   ├── _providers
-│       │   │   └── config.hcl
+│       │   │   └── config.hcl # Global provider's configuration
 │       │   ├── common.hcl
 │       │   ├── common.tfvars
 │       │   ├── stack-example
@@ -34,6 +34,7 @@ This repository embodies a structured approach to organizing Terraform code with
 │       │   │   │       ├── cloudflare-dns-zone
 │       │   │   │       │   ├── .terraform.lock.hcl
 │       │   │   │       │   ├── module.hcl
+│       │   │   │       │   ├── providers.hcl # Local provider's configuration for this specific module
 │       │   │   │       │   ├── terraform.tfvars
 │       │   │   │       │   └── terragrunt.hcl
 │       │   │   │       ├── random-string
@@ -41,6 +42,7 @@ This repository embodies a structured approach to organizing Terraform code with
 │       │   │   │       │   ├── .terraform.lock.hcl
 │       │   │   │       │   ├── .terragrunt-version
 │       │   │   │       │   ├── module.hcl
+│       │   │   │       │   ├── providers.hcl # Local provider's configuration for this specific module
 │       │   │   │       │   ├── terraform.tfvars
 │       │   │   │       │   └── terragrunt.hcl
 │       │   │   │       ├── region.hcl

--- a/infra/terraform/live/stack-example/prod/global/cloudflare-dns-zone/providers.hcl
+++ b/infra/terraform/live/stack-example/prod/global/cloudflare-dns-zone/providers.hcl
@@ -1,0 +1,42 @@
+locals {
+  # ---------------------------------------------------------------------------------------------------------------------
+  # PROVIDER CONFIGURATIONS
+  # This section centralizes the configuration of Terraform providers, such as Cloudflare and AWS, using Terraform's
+  # heredoc syntax for inline definition. This approach allows for dynamic, environment-specific configuration of
+  # providers through environment variables, enhancing the flexibility and security of provider setups. Direct use of
+  # heredoc syntax within the Terragrunt configuration eliminates the need for external template files, streamlining
+  # the codebase and simplifying the management of provider configurations.
+  #
+  # Each provider configuration includes:
+  # - `enabled`: A flag (sourced from an environment variable) indicating whether the provider should be configured.
+  #              This allows for conditional inclusion of providers based on the deployment context or environment.
+  # - `content`: The Terraform configuration for the provider, including authentication details and any other
+  #              provider-specific settings. Sensitive information, such as API keys, is securely sourced from
+  #              environment variables.
+  #
+  # This modular and dynamic approach to configuring providers supports best practices in security and infrastructure
+  # code management, enabling selective provider use and environment-specific configurations without altering the
+  # core codebase.
+  # ---------------------------------------------------------------------------------------------------------------------
+  providers = {
+    cloudflare = {
+      enabled = get_env("TG_PROVIDER_CLOUDFLARE_ENABLED", true)
+      content = <<EOF
+provider "cloudflare" {
+  email   = "${get_env("CLOUDFLARE_EMAIL", "atorres.ruiz@hotmail.com")}"
+  api_key = "${get_env("CLOUDFLARE_API_KEY", "0f2d823b38e5155df231b9cc5bedab1c8f3b8")}"
+}
+EOF
+    },
+    # Additional providers can be added here following the same pattern.
+  }
+
+  # ---------------------------------------------------------------------------------------------------------------------
+  # PROVIDERS CONTENT
+  # Generate the providers' configuration content only for enabled providers.
+  # ---------------------------------------------------------------------------------------------------------------------
+  providers_content = [
+    for provider, details in local.providers : details.content
+    if details.enabled && details.content != ""
+  ]
+}

--- a/infra/terraform/live/stack-example/prod/global/random-string/providers.hcl
+++ b/infra/terraform/live/stack-example/prod/global/random-string/providers.hcl
@@ -1,0 +1,41 @@
+locals {
+  # ---------------------------------------------------------------------------------------------------------------------
+  # PROVIDER CONFIGURATIONS
+  # This section centralizes the configuration of Terraform providers, such as Cloudflare, AWS, and Random, using Terraform's
+  # heredoc syntax for inline definition. This approach allows for dynamic, environment-specific configuration of
+  # providers through environment variables, enhancing the flexibility and security of provider setups. Direct use of
+  # heredoc syntax within the Terragrunt configuration eliminates the need for external template files, streamlining
+  # the codebase and simplifying the management of provider configurations.
+  #
+  # Each provider configuration includes:
+  # - `enabled`: A flag (sourced from an environment variable) indicating whether the provider should be configured.
+  #              This allows for conditional inclusion of providers based on the deployment context or environment.
+  # - `content`: The Terraform configuration for the provider, including authentication details and any other
+  #              provider-specific settings. Sensitive information is securely sourced from environment variables.
+  #
+  # This modular and dynamic approach to configuring providers supports best practices in security and infrastructure
+  # code management, enabling selective provider use and environment-specific configurations without altering the
+  # core codebase.
+  # ---------------------------------------------------------------------------------------------------------------------
+  providers = {
+    random = {
+      enabled = get_env("TG_PROVIDER_RANDOM_ENABLED", true)
+      content = <<EOF
+provider "random" {
+  # The random provider does not require authentication, but this block is included
+  # for consistency and to allow future configuration if necessary.
+}
+EOF
+    }
+    # Additional providers can be added here following the same pattern.
+  }
+
+  # ---------------------------------------------------------------------------------------------------------------------
+  # PROVIDERS CONTENT
+  # Generate the providers' configuration content only for enabled providers.
+  # ---------------------------------------------------------------------------------------------------------------------
+  providers_content = [
+    for provider, details in local.providers : details.content
+    if details.enabled && details.content != null
+  ]
+}


### PR DESCRIPTION
Update the local provider's configuration for the specific module with a new
`providers.hcl` file. This file includes dynamic provider configurations using
Terraform's heredoc syntax, enhancing flexibility and security by sourcing
information from environment variables. This approach centralizes provider
configurations, supporting selective provider use and environment-specific
settings without modifying the core codebase.