### PR TITLE
ci: Update provider content format in Terraform files

### DIFF
--- a/infra/terraform/live/stack-example/prod/global/cloudflare-dns-zone/providers.hcl
+++ b/infra/terraform/live/stack-example/prod/global/cloudflare-dns-zone/providers.hcl
@@ -21,7 +21,7 @@ locals {
   providers = {
     cloudflare = {
       enabled = get_env("TG_PROVIDER_CLOUDFLARE_ENABLED", true)
-      content = <<EOF
+      content = <<-EOF
 provider "cloudflare" {
   email   = "${get_env("CLOUDFLARE_EMAIL", "atorres.ruiz@hotmail.com")}"
   api_key = "${get_env("CLOUDFLARE_API_KEY", "0f2d823b38e5155df231b9cc5bedab1c8f3b8")}"

--- a/infra/terraform/live/stack-example/prod/global/random-string/providers.hcl
+++ b/infra/terraform/live/stack-example/prod/global/random-string/providers.hcl
@@ -20,7 +20,7 @@ locals {
   providers = {
     random = {
       enabled = get_env("TG_PROVIDER_RANDOM_ENABLED", true)
-      content = <<EOF
+      content = <<-EOF
 provider "random" {
   # The random provider does not require authentication, but this block is included
   # for consistency and to allow future configuration if necessary.


### PR DESCRIPTION
Changed provider content format in Terraform files to use <<-EOF instead of <<EOF
for consistency and future configurability.