### PR TITLE
refactor: Update cloudflare credentials in providers.hcl

### DIFF
--- a/infra/terraform/live/stack-example/prod/global/cloudflare-dns-zone/providers.hcl
+++ b/infra/terraform/live/stack-example/prod/global/cloudflare-dns-zone/providers.hcl
@@ -23,8 +23,8 @@ locals {
       enabled = get_env("TG_PROVIDER_CLOUDFLARE_ENABLED", true)
       content = <<-EOF
 provider "cloudflare" {
-  email   = "${get_env("CLOUDFLARE_EMAIL", "atorres.ruiz@hotmail.com")}"
-  api_key = "${get_env("CLOUDFLARE_API_KEY", "0f2d823b38e5155df231b9cc5bedab1c8f3b8")}"
+  email   = "${get_env("CLOUDFLARE_EMAIL", "my@email.com")}"
+  api_key = "${get_env("CLOUDFLARE_API_KEY", "0f2dsssda8f3b8")}"
 }
 EOF
     },


### PR DESCRIPTION
Update the email and api_key values in the cloudflare provider block to use
generic placeholders instead of specific email and api key values. This change
enhances security by not exposing sensitive information in the codebase.